### PR TITLE
Add services section to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: php
 php:
 - 7.0
 - 7.1
+services:
+  - mysql
 notifications:
   email:
     on_success: never


### PR DESCRIPTION
Without `services` section, travis container doesn't start MySQL.
https://docs.travis-ci.com/user/database-setup/#mysql